### PR TITLE
Rename viariable as an another configuration parameter

### DIFF
--- a/docs/smtp.md
+++ b/docs/smtp.md
@@ -1,5 +1,5 @@
 
-# `main.cf` 
+# `main.cf`
 
 ## smtp
 
@@ -25,7 +25,7 @@ postfix_smtp:
     security_level: encrypt
     note_starttls_offer: true
     wrappermode: true
-    cafile: ""
+    ca_file: ""
     cert_file: ""
     key_file: ""
     loglevel: 1

--- a/molecule/default/group_vars/all/vars.yml
+++ b/molecule/default/group_vars/all/vars.yml
@@ -50,7 +50,7 @@ postfix_smtp:
   tls:
     security_level: encrypt
     note_starttls_offer: true
-    cafile: ""
+    ca_file: ""
 
 postfix_relay:
   use_tls: true

--- a/templates/etc/postfix/main.cf.d/smtp.j2
+++ b/templates/etc/postfix/main.cf.d/smtp.j2
@@ -7,9 +7,9 @@ smtp_tls_loglevel              = {{ postfix_smtp.tls.loglevel }}
 smtp_tls_security_level        = {{ postfix_smtp.tls.security_level }}
 smtp_tls_wrappermode           = {{ postfix_smtp.tls.wrappermode | bool | ternary('yes', 'no') }}
 smtp_tls_note_starttls_offer   = {{ postfix_smtp.tls.note_starttls_offer | bool | ternary('yes', 'no') }}
-  {% if postfix_smtp.tls.cafile is defined and
-        postfix_smtp.tls.cafile | length > 0 %}
-smtp_tls_CAfile                = {{ postfix_smtp.tls.cafile }}
+  {% if postfix_smtp.tls.ca_file is defined and
+        postfix_smtp.tls.ca_file | length > 0 %}
+smtp_tls_CAfile                = {{ postfix_smtp.tls.ca_file }}
   {% endif %}
   {% if postfix_smtp.tls.cert_file is defined and
         postfix_smtp.tls.cert_file | length > 0 %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -85,7 +85,7 @@ postfix_defaults_smtp:
     security_level: encrypt
     note_starttls_offer: true
     wrappermode: true
-    cafile: ""
+    ca_file: ""
     cert_file: ""
     key_file: ""
     loglevel: 1


### PR DESCRIPTION
```
  tls:
    security_level: encrypt
    note_starttls_offer: true
    wrappermode: true
    ca_file: ""
    cert_file: ""
    key_file: ""
```